### PR TITLE
Increase compatibility with older ansible versions

### DIFF
--- a/tasks/include_vars.yml
+++ b/tasks/include_vars.yml
@@ -1,0 +1,7 @@
+---
+- include_vars: "{{item}}"
+  with_first_found:
+  - "../vars/{{ansible_distribution}}-{{ansible_distribution_version}}.yml"
+  - "../vars/{{ansible_distribution}}.yml"
+  - "../vars/{{ansible_os_family}}.yml"
+  - "../vars/default.yml"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,15 +2,10 @@
 - include: compat.yml
 - include: get_key.yml
 
+- include: include_vars.yml
+
 - include: Debian.yml
   when: ansible_os_family == 'Debian'
-
-- include_vars: "{{item}}"
-  with_first_found:
-  - "../vars/{{ansible_distribution}}-{{ansible_distribution_major_version | int}}.yml"
-  - "../vars/{{ansible_distribution}}.yml"
-  - "../vars/{{ansible_os_family}}.yml"
-  - "../vars/default.yml"
 
 - name: install handbrake with default package manager
   action: "{{backcompat_pkg_mgr}} name={{package_name}}"


### PR DESCRIPTION
Switch ansible_distribution_major_version to
ansible_distribution_version.  Extract file include_vars.yml
